### PR TITLE
Do not run regular build on merge

### DIFF
--- a/.github/workflows/build-sign.yml
+++ b/.github/workflows/build-sign.yml
@@ -1,4 +1,4 @@
-name: Build, sign, and upload
+name: Build, test, sign, and upload
 
 on:
   push:
@@ -32,6 +32,7 @@ jobs:
             -Psign \
             -Dgpg.keyname=6C063BAA00065DFED08D7CD6B21CB73DBBF60FE5 \
             clean \
+            test \
             verify
 
       - name: Upload build artifacts (JARs + .asc)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,6 @@
 name: Build and Test
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
     branches:
       - master


### PR DESCRIPTION
- We already have our build/test/sign task for post-merge, no need to run build/test as well.